### PR TITLE
Adds "print" to SYNOPSIS

### DIFF
--- a/lib/Data/Difflet.pm
+++ b/lib/Data/Difflet.pm
@@ -170,7 +170,7 @@ Data::Difflet - Ultra special pretty cute diff generator Mark II
     use Data::Difflet;
 
     my $difflet = Data::Difflet->new();
-    $difflet->compare(
+    print $difflet->compare(
         {
             a => 2,
             c => 5,


### PR DESCRIPTION
I copy/pasted the SYNOPSIS to test it out in a script and there was no output until I added a print, so I thought it would be helpful to make it explicit.  :)
