### PR TITLE
fix the problem when execute test file with prove

### DIFF
--- a/lib/Test/Difflet.pm
+++ b/lib/Test/Difflet.pm
@@ -33,7 +33,7 @@ sub difflet_is_deeply {
             $builder->diag($difflet->compare($got, $expected));
         }
     } else {
-        $builder->is_deeply($got, $expected, $msg);
+        is_deeply($got, $expected, $msg);
     }
 }
 


### PR DESCRIPTION
When we execute the test file with prove, we've got an error message.
- Can't locate object method "is_deeply" via package "Test::Builder"

I simply replaced the call $builder->is_deeply() with is_deeply().
