### PR TITLE
fix for hash randomization

### DIFF
--- a/lib/Test/Difflet.pm
+++ b/lib/Test/Difflet.pm
@@ -41,7 +41,7 @@ sub _eq_deeply {
     my ($a, $b) = @_;
     local $Data::Dumper::Terse = 1;
     local $Data::Dumper::Indent = 0;
-    local $Data::Dumper::SortKeys = 1;
+    local $Data::Dumper::Sortkeys = 1;
     return Dumper($a) eq Dumper($b);
 }
 

--- a/t/02-randomization.t
+++ b/t/02-randomization.t
@@ -1,0 +1,10 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More 0.96;
+use Test::Difflet qw/is_deeply/;
+
+is_deeply {a => 1, b => 2, c => 3}, {a => 1, b => 2, c => 3};
+
+done_testing;
+


### PR DESCRIPTION
Test::Difflet's is_deeply() sometimes fails due to hash randomization.
