### PR TITLE
Override Test::More::is_deeply when use with "qw(is_deeply)"

### DIFF
--- a/lib/Test/Difflet.pm
+++ b/lib/Test/Difflet.pm
@@ -14,6 +14,7 @@ sub import {
         if ($_ eq 'is_deeply') {
             no warnings 'redefine';
             *{"${pkg}::is_deeply"} = \&difflet_is_deeply;
+            *Test::More::is_deeply = \&difflet_is_deeply;
         }
     }
     *{"${pkg}::difflet_is_deeply"} = \&difflet_is_deeply;


### PR DESCRIPTION
foo.tには `use Test::Difflet` は書きたくないけど、自分の環境では個人的に is_deeply として difflet_is_deeply を使いたかったので、~/.proverc に `--exec "perl -Ilib -MTest::Difflet=is_deeply"` って書いたんだけどうまく動かなかった。

でも、Test::Flatten は .proverc の --exec に書いてうまくいくよなーと思って見たら Test::More::subtest を override してたんで、Test::Difflet も Test::More::is_deeply を override してみました。
